### PR TITLE
issue with checking for incorrect int value

### DIFF
--- a/src/CodeManipulation/Stream.php
+++ b/src/CodeManipulation/Stream.php
@@ -186,7 +186,7 @@ class Stream
 
     public function stream_lock($operation)
     {
-        if ($operation === '0') {
+        if ($operation === '0' || $operation === 0  ) {
             $operation = LOCK_EX;
         }
         return flock($this->resource, $operation);


### PR DESCRIPTION
while testing using monkeybrain and phpcs, stream was being called with a 0 parameter.  As a quick fast fix the code also checks for int 0 values.